### PR TITLE
Fix for GLTextureCache

### DIFF
--- a/applications/defrac/platformer/src/java/platformer/gl/GLTextureCache.java
+++ b/applications/defrac/platformer/src/java/platformer/gl/GLTextureCache.java
@@ -22,35 +22,14 @@ public final class GLTextureCache
 
 		if( null == glTexture )
 		{
-			final int width = textureData.width();
-			final int height = textureData.height();
-
-			final byte[] bytes = new byte[ width * height * 4 ];
-
-			boolean valid = true;
-
-			try
-			{
-				// Does not work inside a defrac.ui.GLSurface context
-				// throws java.lang.ArrayIndexOutOfBoundsException: 0
-				textureData.loadPixels(  ).getPixels( 0, 0, width, height, bytes, 0 );
-			}
-			catch( Throwable t )
-			{
-				t.printStackTrace();
-				valid = false;
-			}
-
 			glTexture = glSubstrate.createTexture();
 			glSubstrate.bindTexture( GL.TEXTURE_2D, glTexture);
-			glSubstrate.texImage2D( GL.TEXTURE_2D, 0, GL.RGBA, width, height, 0, GL.RGBA, GL.UNSIGNED_BYTE, bytes );
 			glSubstrate.texParameteri( GL.TEXTURE_2D, GL.TEXTURE_MAG_FILTER, GL.LINEAR );
 			glSubstrate.texParameteri( GL.TEXTURE_2D, GL.TEXTURE_MIN_FILTER, GL.LINEAR_MIPMAP_NEAREST);
-			glSubstrate.generateMipmap(GL.TEXTURE_2D);
+			textureData.texImage2D( glSubstrate, GL.TEXTURE_2D, 0, textureData.format().hasAlpha() ? GL.RGBA : GL.RGB, 0);
 			glSubstrate.bindTexture(GL.TEXTURE_2D, null);
 
-			if( valid )
-				cache.put( textureData, glTexture );
+			cache.put( textureData, glTexture );
 		}
 
 		return glTexture;


### PR DESCRIPTION
The TextureData API already provides texImage2D so we don't have to
obtain the pixel data by an expensive TextureData#loadPixels round trip.
